### PR TITLE
Make DocGen query builder limits configurable via Custom Settings

### DIFF
--- a/force-app/main/default/classes/DocGenSetupController.cls
+++ b/force-app/main/default/classes/DocGenSetupController.cls
@@ -23,6 +23,19 @@ public with sharing class DocGenSetupController {
         upsert settings;
     }
 
+    @AuraEnabled(cacheable=true)
+    public static Map<String, Integer> getBuilderLimits() {
+        DocGen_Settings__c settings = DocGen_Settings__c.getOrgDefaults();
+        Integer maxParent = settings.Max_Parent_Fields__c != null
+            ? (Integer) settings.Max_Parent_Fields__c : 10;
+        Integer maxChild = settings.Max_Child_Lists__c != null
+            ? (Integer) settings.Max_Child_Lists__c : 5;
+        return new Map<String, Integer>{
+            'maxParentFields' => maxParent,
+            'maxChildLists' => maxChild
+        };
+    }
+
     @AuraEnabled
     public static void saveEmailBrandingSettings(String companyName, String logoUrl, String brandColor, String emailSubject, String emailMessage, String footerText) {
         if (!FeatureManagement.checkPermission('DocGen_Admin_Access') &&

--- a/force-app/main/default/lwc/docGenQueryBuilder/docGenQueryBuilder.js
+++ b/force-app/main/default/lwc/docGenQueryBuilder/docGenQueryBuilder.js
@@ -5,7 +5,12 @@ import getObjectFields from '@salesforce/apex/DocGenController.getObjectFields';
 import getChildRelationships from '@salesforce/apex/DocGenController.getChildRelationships';
 import getParentRelationships from '@salesforce/apex/DocGenController.getParentRelationships';
 import previewRecordData from '@salesforce/apex/DocGenController.previewRecordData';
+import getBuilderLimits from '@salesforce/apex/DocGenSetupController.getBuilderLimits';
 import { refreshApex } from '@salesforce/apex';
+
+// Fallback defaults if custom setting has no value
+const DEFAULT_MAX_PARENT_FIELDS = 10;
+const DEFAULT_MAX_CHILD_LISTS = 5;
 
 export default class DocGenQueryBuilder extends LightningElement {
     @track objectOptions = [];
@@ -47,9 +52,25 @@ export default class DocGenQueryBuilder extends LightningElement {
     @track showParentFieldDropdown = false;
     @track filteredParentFieldOptions = [];
 
+    // --- Dynamic Limits (from DocGen_Settings__c) ---
+    maxParentFields = DEFAULT_MAX_PARENT_FIELDS;
+    maxChildLists = DEFAULT_MAX_CHILD_LISTS;
+
+    @wire(getBuilderLimits)
+    wiredLimits({ error, data }) {
+        if (data) {
+            this.maxParentFields = data.maxParentFields || DEFAULT_MAX_PARENT_FIELDS;
+            this.maxChildLists = data.maxChildLists || DEFAULT_MAX_CHILD_LISTS;
+        } else if (error) {
+            // Fallback to defaults silently
+            this.maxParentFields = DEFAULT_MAX_PARENT_FIELDS;
+            this.maxChildLists = DEFAULT_MAX_CHILD_LISTS;
+        }
+    }
+
     // --- New Mode ---
     @api showTagsOnly = false;
-    
+
     // --- Layout Getters ---
     get mainColumnClass() { 
         return this.showTagsOnly ? 'slds-hide' : 'slds-col slds-size_2-of-3';
@@ -464,15 +485,15 @@ export default class DocGenQueryBuilder extends LightningElement {
         const warnings = [];
         
         // 1. Parent Fields Count
-        if (this.parentFieldSelection.length >= 10) {
-            warnings.push(`Maximum strict limit of 10 parent fields reached. You cannot add more.`);
-        } else if (this.parentFieldSelection.length > 8) {
-             warnings.push(`Approaching parent field limit (${this.parentFieldSelection.length}/10).`);
+        if (this.parentFieldSelection.length >= this.maxParentFields) {
+            warnings.push(`Maximum limit of ${this.maxParentFields} parent fields reached. You cannot add more.`);
+        } else if (this.parentFieldSelection.length > Math.floor(this.maxParentFields * 0.9)) {
+             warnings.push(`Approaching parent field limit (${this.parentFieldSelection.length}/${this.maxParentFields}).`);
         }
-        
+
         // 2. Child Lists Count
-        if (this.childConfigs.length >= 5) {
-            warnings.push(`Maximum strict limit of 5 related lists reached. You cannot add more.`);
+        if (this.childConfigs.length >= this.maxChildLists) {
+            warnings.push(`Maximum limit of ${this.maxChildLists} related lists reached. You cannot add more.`);
         }
         
         // 3. Total Fields
@@ -837,20 +858,20 @@ export default class DocGenQueryBuilder extends LightningElement {
 
     get isAddParentDisabled() {
         // Disabled if nothing selected OR limit reached
-        if (this.parentFieldSelection.length >= 10) return true;
+        if (this.parentFieldSelection.length >= this.maxParentFields) return true;
         return !this.selectedParentFields || this.selectedParentFields.length === 0;
     }
     
     get isAddChildDisabled() {
-         return this.childConfigs.length >= 5;
+         return this.childConfigs.length >= this.maxChildLists;
     }
 
     addParentField() {
-        if (this.parentFieldSelection.length >= 10) {
+        if (this.parentFieldSelection.length >= this.maxParentFields) {
             this.dispatchEvent(
                 new ShowToastEvent({
                     title: 'Limit Reached',
-                    message: 'You cannot add more than 10 parent fields.',
+                    message: `You cannot add more than ${this.maxParentFields} parent fields.`,
                     variant: 'error',
                 })
             );
@@ -858,7 +879,7 @@ export default class DocGenQueryBuilder extends LightningElement {
         }
 
         if (this.selectedParentRel && this.selectedParentFields.length > 0) {
-            const remaining = 10 - this.parentFieldSelection.length;
+            const remaining = this.maxParentFields - this.parentFieldSelection.length;
             let newFields = [];
             
             // Slice if they tried to select more than allowed in one go
@@ -867,7 +888,7 @@ export default class DocGenQueryBuilder extends LightningElement {
                  this.dispatchEvent(
                     new ShowToastEvent({
                         title: 'Selection Truncated',
-                        message: `Only added ${remaining} fields to stay within the limit of 10.`,
+                        message: `Only added ${remaining} fields to stay within the limit of ${this.maxParentFields}.`,
                         variant: 'warning',
                     })
                 );
@@ -934,11 +955,11 @@ export default class DocGenQueryBuilder extends LightningElement {
 
     // Updated Logic for Child Checkboxes
     addChildConfig() {
-        if (this.childConfigs.length >= 5) {
+        if (this.childConfigs.length >= this.maxChildLists) {
              this.dispatchEvent(
                 new ShowToastEvent({
                     title: 'Limit Reached',
-                    message: 'You cannot add more than 5 related lists.',
+                    message: `You cannot add more than ${this.maxChildLists} related lists.`,
                     variant: 'error',
                 })
             );

--- a/force-app/main/default/objects/DocGen_Settings__c/fields/Max_Child_Lists__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Settings__c/fields/Max_Child_Lists__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Max_Child_Lists__c</fullName>
+    <defaultValue>5</defaultValue>
+    <description>Maximum number of child relationship lists allowed in the DocGen query builder. Controls the UI limit in the template configuration.</description>
+    <externalId>false</externalId>
+    <label>Max Child Lists</label>
+    <precision>18</precision>
+    <required>false</required>
+    <scale>0</scale>
+    <type>Number</type>
+</CustomField>

--- a/force-app/main/default/objects/DocGen_Settings__c/fields/Max_Parent_Fields__c.field-meta.xml
+++ b/force-app/main/default/objects/DocGen_Settings__c/fields/Max_Parent_Fields__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Max_Parent_Fields__c</fullName>
+    <defaultValue>10</defaultValue>
+    <description>Maximum number of parent (relationship) fields allowed in the DocGen query builder. Controls the UI limit in the template configuration.</description>
+    <externalId>false</externalId>
+    <label>Max Parent Fields</label>
+    <precision>18</precision>
+    <required>false</required>
+    <scale>0</scale>
+    <type>Number</type>
+</CustomField>


### PR DESCRIPTION
## Problem

The `docGenQueryBuilder` LWC hardcodes a maximum of **10 parent fields** and **5 child lists**. These limits are enforced purely at the UI layer — `DocGenDataRetriever` and the underlying SOQL engine can handle significantly more fields without issue.

This means every org that outgrows the default limits must either:
- Fork the component and maintain a patched version
- Create formula fields as workarounds to flatten parent traversals
- Request a code deployment for what should be a configuration change

## Proposed solution

Leverage the existing `DocGen_Settings__c` hierarchical custom setting to make both limits admin-configurable. No new objects, no schema bloat — just two Number fields on an object that already stores builder configuration.

### Changes

| File | What | Why |
|------|------|-----|
| `DocGen_Settings__c` | Added `Max_Parent_Fields__c` (default: 10) and `Max_Child_Lists__c` (default: 5) | Store limits alongside existing config |
| `DocGenSetupController.cls` | Added `getBuilderLimits()` cacheable method | Expose limits to LWC with fallback defaults |
| `docGenQueryBuilder.js` | Replaced 8 hardcoded references with `@wire`-fetched values | Consume dynamic limits |

### What this does NOT change

- **Default behavior** — without any custom setting record, limits remain 10/5. Existing users see zero difference.
- **Backend logic** — no changes to `DocGenDataRetriever`, `DocGenService`, or template processing
- **Performance** — hierarchical custom settings are platform-cached; `getBuilderLimits()` is `cacheable=true`. No additional SOQL.
- **API surface** — no breaking changes to any public method

## Alternatives considered

| Approach | Rejected because |
|----------|-----------------|
| Custom Metadata Type | Heavier than needed for two numeric values; `DocGen_Settings__c` already exists and serves this purpose |
| Remove limits entirely | Some guardrail is useful to prevent accidental performance issues; making it configurable preserves the safety net while removing the rigidity |
| Increase hardcoded values | Trades one arbitrary number for another; doesn't solve the underlying inflexibility |